### PR TITLE
feat(platform): add IOC (indicator) support

### DIFF
--- a/enums/indicator.go
+++ b/enums/indicator.go
@@ -1,0 +1,143 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package enums
+
+// ==============================================================================
+// Indicator (IOC) Enums
+// ==============================================================================
+//
+// Mirrors the enum sets declared by the `/public_api/v1/indicators/insert`
+// schema. Underlying Go type is `string`, so callers can hold any value the
+// API surfaces — including ones the OpenAPI spec doesn't yet document — but
+// the named constants are the documented set and should be used as the
+// default. Slice helpers below return the canonical set for use as switch
+// cases, validator inputs, etc.
+
+// ----------------------------------------------------------------------------
+// Indicator Type
+// ----------------------------------------------------------------------------
+
+// IndicatorType is the kind of value an indicator describes.
+//
+// Note: URL is omitted from the OpenAPI insert enum but is present in the
+// live API — verified by GET responses on a live tenant returning
+// `"type": "URL"` records.
+type IndicatorType string
+
+const (
+	IndicatorTypeHash       IndicatorType = "HASH"
+	IndicatorTypeIP         IndicatorType = "IP"
+	IndicatorTypePath       IndicatorType = "PATH"
+	IndicatorTypeDomainName IndicatorType = "DOMAIN_NAME"
+	IndicatorTypeFilename   IndicatorType = "FILENAME"
+	IndicatorTypeMixed      IndicatorType = "MIXED"
+	IndicatorTypeURL        IndicatorType = "URL"
+)
+
+// IndicatorTypes returns the IndicatorType values accepted by the live API.
+// URL is included despite being missing from the OpenAPI spec.
+func IndicatorTypes() []IndicatorType {
+	return []IndicatorType{
+		IndicatorTypeHash,
+		IndicatorTypeIP,
+		IndicatorTypePath,
+		IndicatorTypeDomainName,
+		IndicatorTypeFilename,
+		IndicatorTypeMixed,
+		IndicatorTypeURL,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Indicator Severity
+// ----------------------------------------------------------------------------
+
+// IndicatorSeverity is the severity rating assigned to an indicator. The
+// namespaced `SEV_NNN_X` encoding is what the live API accepts on both
+// reads and writes.
+//
+// Note: SEV_050_CRITICAL is omitted from the OpenAPI severity enum for
+// /indicators/insert but is present in the Cortex UI and accepted by the
+// live API.
+type IndicatorSeverity string
+
+const (
+	IndicatorSeverityInfo     IndicatorSeverity = "SEV_010_INFO"
+	IndicatorSeverityLow      IndicatorSeverity = "SEV_020_LOW"
+	IndicatorSeverityMedium   IndicatorSeverity = "SEV_030_MEDIUM"
+	IndicatorSeverityHigh     IndicatorSeverity = "SEV_040_HIGH"
+	IndicatorSeverityCritical IndicatorSeverity = "SEV_050_CRITICAL"
+)
+
+// IndicatorSeverities returns the IndicatorSeverity values
+func IndicatorSeverities() []IndicatorSeverity {
+	return []IndicatorSeverity{
+		IndicatorSeverityInfo,
+		IndicatorSeverityLow,
+		IndicatorSeverityMedium,
+		IndicatorSeverityHigh,
+		IndicatorSeverityCritical,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Indicator Reputation
+// ----------------------------------------------------------------------------
+
+// IndicatorReputation is a categorical assessment of the indicator's
+// reputation.
+type IndicatorReputation string
+
+const (
+	IndicatorReputationGood         IndicatorReputation = "GOOD"
+	IndicatorReputationBad          IndicatorReputation = "BAD"
+	IndicatorReputationSuspicious   IndicatorReputation = "SUSPICIOUS"
+	IndicatorReputationUnknown      IndicatorReputation = "UNKNOWN"
+	IndicatorReputationNoReputation IndicatorReputation = "NO_REPUTATION"
+)
+
+// IndicatorReputations returns the documented IndicatorReputation values in
+// declaration order.
+func IndicatorReputations() []IndicatorReputation {
+	return []IndicatorReputation{
+		IndicatorReputationGood,
+		IndicatorReputationBad,
+		IndicatorReputationSuspicious,
+		IndicatorReputationUnknown,
+		IndicatorReputationNoReputation,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Indicator Reliability
+// ----------------------------------------------------------------------------
+
+// IndicatorReliability is a single-character reliability rating where A is
+// the most reliable and G the least. The API also accepts the empty string
+// to mean "unset".
+type IndicatorReliability string
+
+const (
+	IndicatorReliabilityA IndicatorReliability = "A"
+	IndicatorReliabilityB IndicatorReliability = "B"
+	IndicatorReliabilityC IndicatorReliability = "C"
+	IndicatorReliabilityD IndicatorReliability = "D"
+	IndicatorReliabilityE IndicatorReliability = "E"
+	IndicatorReliabilityF IndicatorReliability = "F"
+	IndicatorReliabilityG IndicatorReliability = "G"
+)
+
+// IndicatorReliabilities returns the documented IndicatorReliability values
+// in declaration order.
+func IndicatorReliabilities() []IndicatorReliability {
+	return []IndicatorReliability{
+		IndicatorReliabilityA,
+		IndicatorReliabilityB,
+		IndicatorReliabilityC,
+		IndicatorReliabilityD,
+		IndicatorReliabilityE,
+		IndicatorReliabilityF,
+		IndicatorReliabilityG,
+	}
+}

--- a/platform/client.go
+++ b/platform/client.go
@@ -58,6 +58,11 @@ const (
 	// Syslog Integration Endpoints
 	CreateSyslogIntegrationEndpoint = "public_api/v1/integrations/syslog/create"
 	ListSyslogIntegrationsEndpoint  = "public_api/v1/integrations/syslog/get"
+
+	// Indicator (IOC) Endpoints
+	InsertIndicatorsEndpoint = "public_api/v1/indicators/insert"
+	ListIndicatorsEndpoint   = "public_api/v1/indicators/get"
+	DeleteIndicatorsEndpoint = "public_api/v1/indicators/delete"
 )
 
 // Option is a functional option for configuring the client.

--- a/platform/indicators.go
+++ b/platform/indicators.go
@@ -1,0 +1,101 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package platform
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/PaloAltoNetworks/cortex-cloud-go/internal/client"
+	types "github.com/PaloAltoNetworks/cortex-cloud-go/types/platform"
+)
+
+// InsertIndicators uploads one or more IOCs. The endpoint upserts: submit
+// a payload with no `rule_id` to create a new record, or include the
+// server-assigned `rule_id` for an existing record to overwrite it.
+// Per-record failures surface in Errors[] keyed by the original batch
+// position; successful creates/updates appear in AddedObjects/UpdatedObjects.
+//
+// Note: the three indicator endpoints return success bodies at the top
+// level (no `reply` wrapper). Error bodies do come wrapped in `reply` and
+// are handled by the internal client's CortexCloudAPIError path before
+// reaching response unmarshal.
+func (c *Client) InsertIndicators(ctx context.Context, indicators []types.Indicator) (types.InsertIndicatorsResponse, error) {
+	var resp types.InsertIndicatorsResponse
+	_, err := c.internalClient.Do(ctx, http.MethodPost, InsertIndicatorsEndpoint, nil, nil, indicators, &resp, &client.DoOptions{
+		RequestWrapperKeys: []string{"request_data"},
+	})
+	return resp, mapError(err)
+}
+
+// ListIndicators retrieves IOCs matching the provided filter set. Pass an
+// empty Filters slice to list all indicators (capped by the server).
+func (c *Client) ListIndicators(ctx context.Context, req types.ListIndicatorsRequest) (types.ListIndicatorsResponse, error) {
+	var resp types.ListIndicatorsResponse
+	_, err := c.internalClient.Do(ctx, http.MethodPost, ListIndicatorsEndpoint, nil, nil, req, &resp, &client.DoOptions{
+		RequestWrapperKeys: []string{"request_data"},
+	})
+	return resp, mapError(err)
+}
+
+// DeleteIndicators removes IOCs matching the provided filter set and
+// returns the server-assigned rule_ids of the removed records. The API
+// has no by-ID delete; identity is carried in the filter body (typically a
+// single `{field:"indicator",operator:"EQ",value:<id>}` clause). An empty
+// returned slice means the filter matched nothing — callers that treat
+// "delete-by-name on a missing record" as success should ignore the count.
+func (c *Client) DeleteIndicators(ctx context.Context, req types.DeleteIndicatorsRequest) ([]int, error) {
+	var resp types.DeleteIndicatorsResponse
+	_, err := c.internalClient.Do(ctx, http.MethodPost, DeleteIndicatorsEndpoint, nil, nil, req, &resp, &client.DoOptions{
+		RequestWrapperKeys: []string{"request_data"},
+	})
+	return resp.Objects, mapError(err)
+}
+
+// FindIndicatorByID returns the indicator whose server-assigned `rule_id`
+// equals the given value, or nil if no match was found. The OpenAPI lists
+// `rule_id` only in the indicators/get *example*, not in the documented
+// filter-field enum, but the live API accepts it on EQ. Use it when you
+// have the numeric ID but not the indicator string (e.g. cross-referencing
+// audit logs).
+func (c *Client) FindIndicatorByID(ctx context.Context, ruleID int) (*types.Indicator, error) {
+	resp, err := c.ListIndicators(ctx, types.ListIndicatorsRequest{
+		ExtendedView: true,
+		Filters: []types.IndicatorFilter{
+			{Field: "rule_id", Operator: "EQ", Value: ruleID},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.Objects {
+		if resp.Objects[i].RuleID == ruleID {
+			return &resp.Objects[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// FindIndicatorByName is a convenience helper that returns the single
+// indicator whose `indicator` field equals the given value, or nil if no
+// match was found. It is the primary lookup path for Terraform-style
+// resources where the indicator string is the identity.
+func (c *Client) FindIndicatorByName(ctx context.Context, indicator string) (*types.Indicator, error) {
+	resp, err := c.ListIndicators(ctx, types.ListIndicatorsRequest{
+		ExtendedView: true,
+		Filters: []types.IndicatorFilter{
+			{Field: "indicator", Operator: "EQ", Value: indicator},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.Objects {
+		if resp.Objects[i].Indicator == indicator {
+			return &resp.Objects[i], nil
+		}
+	}
+	return nil, nil
+}
+

--- a/platform/indicators_acc_test.go
+++ b/platform/indicators_acc_test.go
@@ -1,0 +1,223 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package platform
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/PaloAltoNetworks/cortex-cloud-go/enums"
+	platformTypes "github.com/PaloAltoNetworks/cortex-cloud-go/types/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccIndicatorLifecycle exercises the full create→read→update→delete
+// path against a live tenant. Configure via the same env vars used by the
+// asset-group acceptance test: TEST_CORTEX_API_URL, TEST_CORTEX_API_KEY,
+// TEST_CORTEX_API_KEY_ID. Run with:
+//
+//	go test -tags=acceptance -run TestAccIndicator -v ./platform/...
+func TestAccIndicatorLifecycle(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	indicatorName := fmt.Sprintf("go-sdk-acctest-%s.example.test", timestamp)
+	original := platformTypes.Indicator{
+		Indicator:                indicatorName,
+		Type:                     enums.IndicatorTypeDomainName,
+		Severity:                 enums.IndicatorSeverityLow,
+		ExpirationDate:           -1,
+		DefaultExpirationEnabled: true,
+		Comment:                  fmt.Sprintf("go-sdk acceptance test %s", timestamp),
+		Reputation:               enums.IndicatorReputationUnknown,
+		Reliability:              enums.IndicatorReliabilityF,
+	}
+
+	// --- Create ---
+	insertResp, err := client.InsertIndicators(ctx, []platformTypes.Indicator{original})
+	require.NoError(t, err, "InsertIndicators (create) failed")
+	require.Empty(t, insertResp.Errors, "unexpected per-record errors: %v", insertResp.Errors)
+	require.Len(t, insertResp.AddedObjects, 1, "expected one added record")
+	require.Empty(t, insertResp.UpdatedObjects, "create path should not populate updated_objects")
+	ruleID := insertResp.AddedObjects[0].ID
+	assert.Positive(t, ruleID)
+	assert.Contains(t, insertResp.AddedObjects[0].Status, "Created")
+
+	// Defer cleanup as early as possible so a panic inside this test
+	// doesn't leak the record.
+	defer func() {
+		ids, delErr := client.DeleteIndicators(ctx, platformTypes.DeleteIndicatorsRequest{
+			Filters: []platformTypes.IndicatorFilter{
+				{Field: "indicator", Operator: "EQ", Value: indicatorName},
+			},
+		})
+		if delErr != nil {
+			t.Logf("cleanup delete failed: %s", delErr.Error())
+		}
+		// Tolerate already-gone — the explicit delete near the end of
+		// the test may have run first.
+		t.Logf("cleanup removed rule_ids: %v", ids)
+	}()
+
+	// --- Read by name ---
+	byName, err := client.FindIndicatorByName(ctx, indicatorName)
+	require.NoError(t, err, "FindIndicatorByName failed")
+	require.NotNil(t, byName, "indicator should exist after insert")
+	assert.Equal(t, ruleID, byName.RuleID)
+	assert.Equal(t, indicatorName, byName.Indicator)
+	assert.Equal(t, enums.IndicatorTypeDomainName, byName.Type)
+	assert.Equal(t, enums.IndicatorSeverityLow, byName.Severity)
+	assert.Equal(t, int64(-1), byName.ExpirationDate)
+	assert.True(t, byName.DefaultExpirationEnabled)
+	assert.Equal(t, original.Comment, byName.Comment)
+	assert.Equal(t, enums.IndicatorReputationUnknown, byName.Reputation)
+	assert.Equal(t, enums.IndicatorReliabilityF, byName.Reliability)
+	// Read-only fields (S3 regression guard): the live API populates
+	// these when extended_view=true; FindIndicatorByName already requests
+	// extended_view.
+	assert.Positive(t, byName.CreationTime, "creation_time should be a unix-epoch-ms")
+	assert.Positive(t, byName.ModificationTime, "modification_time should be a unix-epoch-ms")
+	assert.NotEmpty(t, byName.Status, "status (e.g. ENABLED) should be set")
+	assert.NotEmpty(t, byName.Source, "source (e.g. Public API user (key #N)) should be set")
+	assert.GreaterOrEqual(t, byName.NumberOfIssues, 0)
+
+	// --- Read by ID ---
+	// rule_id filter is undocumented in the OpenAPI field enum but works
+	// against the live API on EQ. This sub-assertion is the canonical
+	// regression guard for B2.
+	byID, err := client.FindIndicatorByID(ctx, ruleID)
+	require.NoError(t, err, "FindIndicatorByID failed")
+	require.NotNil(t, byID, "rule_id lookup should succeed")
+	assert.Equal(t, ruleID, byID.RuleID)
+	assert.Equal(t, indicatorName, byID.Indicator)
+
+	// --- Update via upsert (rule_id-keyed overwrite) ---
+	updated := original
+	updated.RuleID = ruleID
+	updated.Severity = enums.IndicatorSeverityCritical
+	updated.Reputation = enums.IndicatorReputationBad
+	updated.Reliability = enums.IndicatorReliabilityA
+	updated.Comment = original.Comment + " (updated)"
+
+	updateResp, err := client.InsertIndicators(ctx, []platformTypes.Indicator{updated})
+	require.NoError(t, err, "InsertIndicators (update) failed")
+	require.Empty(t, updateResp.Errors, "unexpected per-record errors on update: %v", updateResp.Errors)
+	require.Empty(t, updateResp.AddedObjects, "update path should not populate added_objects")
+	require.Len(t, updateResp.UpdatedObjects, 1, "expected one updated record")
+	assert.Equal(t, ruleID, updateResp.UpdatedObjects[0].ID)
+	assert.Contains(t, updateResp.UpdatedObjects[0].Status, "Updated")
+
+	// Confirm new content lands on read-back.
+	afterUpdate, err := client.FindIndicatorByName(ctx, indicatorName)
+	require.NoError(t, err)
+	require.NotNil(t, afterUpdate)
+	assert.Equal(t, ruleID, afterUpdate.RuleID, "rule_id should be stable across in-place updates")
+	assert.Equal(t, enums.IndicatorSeverityCritical, afterUpdate.Severity)
+	assert.Equal(t, enums.IndicatorReputationBad, afterUpdate.Reputation)
+	assert.Equal(t, enums.IndicatorReliabilityA, afterUpdate.Reliability)
+	assert.Equal(t, updated.Comment, afterUpdate.Comment)
+	assert.GreaterOrEqual(t, afterUpdate.ModificationTime, byName.ModificationTime,
+		"modification_time should be non-decreasing after an update")
+
+	// --- Delete by name ---
+	deleted, err := client.DeleteIndicators(ctx, platformTypes.DeleteIndicatorsRequest{
+		Filters: []platformTypes.IndicatorFilter{
+			{Field: "indicator", Operator: "EQ", Value: indicatorName},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, deleted, 1, "expected exactly one record removed")
+	assert.Equal(t, ruleID, deleted[0])
+
+	// Confirm gone.
+	gone, err := client.FindIndicatorByName(ctx, indicatorName)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "indicator should be absent after delete")
+}
+
+// TestAccIndicatorIdempotentDelete pins C1: /indicators/delete returns
+// `{objects_count: 0, objects: []}` (no error) when the filter matches
+// nothing.
+func TestAccIndicatorIdempotentDelete(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	missing := fmt.Sprintf("go-sdk-acctest-missing-%s.example.test", timestamp)
+	ids, err := client.DeleteIndicators(ctx, platformTypes.DeleteIndicatorsRequest{
+		Filters: []platformTypes.IndicatorFilter{
+			{Field: "indicator", Operator: "EQ", Value: missing},
+		},
+	})
+	require.NoError(t, err, "deleting a non-existent indicator should not error")
+	assert.Empty(t, ids, "expected zero rule_ids returned for missing record")
+}
+
+// TestAccIndicatorURLType verifies B1 — `type=URL` is accepted by the live
+// API even though it's omitted from the OpenAPI insert enum. SEV_050_CRITICAL
+// is verified at the same time.
+func TestAccIndicatorURLType(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	indicatorURL := fmt.Sprintf("https://go-sdk-acctest-%s.example.test/probe", timestamp)
+	resp, err := client.InsertIndicators(ctx, []platformTypes.Indicator{{
+		Indicator:                indicatorURL,
+		Type:                     enums.IndicatorTypeURL,
+		Severity:                 enums.IndicatorSeverityCritical,
+		ExpirationDate:           -1,
+		DefaultExpirationEnabled: true,
+		Reputation:               enums.IndicatorReputationBad,
+		Reliability:              enums.IndicatorReliabilityA,
+		Comment:                  "URL + SEV_050_CRITICAL acceptance probe",
+	}})
+	require.NoError(t, err)
+	require.Empty(t, resp.Errors, "URL type should be accepted: %v", resp.Errors)
+	require.Len(t, resp.AddedObjects, 1)
+	ruleID := resp.AddedObjects[0].ID
+
+	defer func() {
+		_, _ = client.DeleteIndicators(ctx, platformTypes.DeleteIndicatorsRequest{
+			Filters: []platformTypes.IndicatorFilter{
+				{Field: "indicator", Operator: "EQ", Value: indicatorURL},
+			},
+		})
+	}()
+
+	got, err := client.FindIndicatorByID(ctx, ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, enums.IndicatorTypeURL, got.Type)
+	assert.Equal(t, enums.IndicatorSeverityCritical, got.Severity)
+}
+
+// TestAccIndicatorBooleanFilter verifies L2 — the
+// `default_expiration_enabled` filter requires a JSON boolean. Sending the
+// value as a JSON bool (the SDK shape) succeeds; this test pins the wire
+// type contract end-to-end. The negative case (string would 500) lives in
+// the unit tests where it can be exercised without touching the tenant.
+func TestAccIndicatorBooleanFilter(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+
+	resp, err := client.ListIndicators(ctx, platformTypes.ListIndicatorsRequest{
+		ExtendedView: true,
+		Filters: []platformTypes.IndicatorFilter{
+			{Field: "default_expiration_enabled", Operator: "EQ", Value: true},
+		},
+		SearchTo: 1,
+	})
+	require.NoError(t, err, "boolean filter sent as JSON bool should not error")
+	// We can't assert a specific count (depends on tenant state), only
+	// that the call decodes cleanly into the SDK type.
+	assert.GreaterOrEqual(t, resp.ObjectsCount, 0)
+}

--- a/platform/indicators_test.go
+++ b/platform/indicators_test.go
@@ -1,0 +1,459 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/PaloAltoNetworks/cortex-cloud-go/enums"
+	platformTypes "github.com/PaloAltoNetworks/cortex-cloud-go/types/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+// indicatorInsertRequest mirrors the body shape /indicators/insert expects:
+// `{ "request_data": [<Indicator>, ...] }`.
+type indicatorInsertRequest struct {
+	RequestData []platformTypes.Indicator `json:"request_data"`
+}
+
+// indicatorFilterRequest mirrors /indicators/get and /indicators/delete:
+// `{ "request_data": { "filters": [...], ... } }`.
+type indicatorFilterRequest struct {
+	RequestData platformTypes.ListIndicatorsRequest `json:"request_data"`
+}
+
+// indicatorDeleteRequest mirrors the delete body — Filters is the only
+// member that gets populated by the SDK helpers, but we keep the type
+// permissive so the unmarshal won't fail on unexpected keys.
+type indicatorDeleteRequest struct {
+	RequestData platformTypes.DeleteIndicatorsRequest `json:"request_data"`
+}
+
+// --- InsertIndicators ------------------------------------------------------
+
+func TestClient_InsertIndicators(t *testing.T) {
+	t.Run("create returns added_objects with new rule_id", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/"+InsertIndicatorsEndpoint, r.URL.Path)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var req indicatorInsertRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData, 1)
+			assert.Equal(t, "evil.example.com", req.RequestData[0].Indicator)
+			assert.Equal(t, enums.IndicatorTypeDomainName, req.RequestData[0].Type)
+			assert.Equal(t, enums.IndicatorSeverityHigh, req.RequestData[0].Severity)
+			// rule_id is omitempty and absent on create.
+			assert.Zero(t, req.RequestData[0].RuleID)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [{"id": 42, "status": "Created a new indicator with the ID: 42 successfully"}],
+				"updated_objects": [],
+				"errors": []
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertIndicators(context.Background(), []platformTypes.Indicator{
+			{
+				Indicator: "evil.example.com",
+				Type:      enums.IndicatorTypeDomainName,
+				Severity:  enums.IndicatorSeverityHigh,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.AddedObjects, 1)
+		assert.Equal(t, 42, resp.AddedObjects[0].ID)
+		assert.Contains(t, resp.AddedObjects[0].Status, "Created")
+		assert.Empty(t, resp.UpdatedObjects)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("update returns updated_objects when rule_id is supplied", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var req indicatorInsertRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData, 1)
+			assert.Equal(t, 42, req.RequestData[0].RuleID)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [],
+				"updated_objects": [{"id": 42, "status": "Updated the indicator with the ID: 42 successfully"}],
+				"errors": []
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertIndicators(context.Background(), []platformTypes.Indicator{
+			{
+				RuleID:    42,
+				Indicator: "evil.example.com",
+				Type:      enums.IndicatorTypeDomainName,
+				Severity:  enums.IndicatorSeverityHigh,
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.UpdatedObjects, 1)
+		assert.Equal(t, 42, resp.UpdatedObjects[0].ID)
+		assert.Empty(t, resp.AddedObjects)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("errors are decoded as {index,status} objects (not strings)", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [],
+				"updated_objects": [],
+				"errors": [
+					{"index": 0, "status": "Failed to create indicator due to: Invalid IOC indicator"}
+				]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertIndicators(context.Background(), []platformTypes.Indicator{{
+			Indicator: "not-a-url",
+			Type:      enums.IndicatorTypeURL,
+			Severity:  enums.IndicatorSeverityLow,
+		}})
+		require.NoError(t, err)
+		require.Len(t, resp.Errors, 1)
+		assert.Equal(t, 0, resp.Errors[0].Index)
+		assert.Contains(t, resp.Errors[0].Status, "Invalid IOC indicator")
+		assert.Empty(t, resp.AddedObjects)
+		assert.Empty(t, resp.UpdatedObjects)
+	})
+
+	t.Run("success body is read at top level (no reply wrapper)", func(t *testing.T) {
+		// Regression guard for L3: the SDK should NOT expect a reply
+		// wrapper on success. If a future refactor reintroduces
+		// ResponseWrapperKeys: ["reply"] this test will fail because the
+		// wrapped body below has no "reply" key.
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [{"id": 1, "status": "ok"}],
+				"updated_objects": [],
+				"errors": []
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertIndicators(context.Background(), []platformTypes.Indicator{{
+			Indicator: "x", Type: enums.IndicatorTypeHash, Severity: enums.IndicatorSeverityInfo,
+		}})
+		require.NoError(t, err)
+		assert.Equal(t, 1, resp.AddedObjects[0].ID)
+	})
+}
+
+// --- ListIndicators --------------------------------------------------------
+
+func TestClient_ListIndicators(t *testing.T) {
+	t.Run("returns objects with read-only fields populated", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/"+ListIndicatorsEndpoint, r.URL.Path)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req indicatorFilterRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			assert.True(t, req.RequestData.ExtendedView)
+			require.Len(t, req.RequestData.Filters, 1)
+			assert.Equal(t, "indicator", req.RequestData.Filters[0].Field)
+			assert.Equal(t, "EQ", req.RequestData.Filters[0].Operator)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"objects_count": 1,
+				"objects_type": "indicator",
+				"objects": [{
+					"rule_id": 57,
+					"indicator": "virus1.exe",
+					"type": "FILENAME",
+					"severity": "SEV_040_HIGH",
+					"expiration_date": -1,
+					"default_expiration_enabled": true,
+					"comment": "test",
+					"reputation": "BAD",
+					"reliability": "C",
+					"creation_time": 1781000000000,
+					"modification_time": 1781000001000,
+					"status": "ENABLED",
+					"source": "Public API user (key #30)",
+					"number_of_issues": 7
+				}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.ListIndicators(context.Background(), platformTypes.ListIndicatorsRequest{
+			ExtendedView: true,
+			Filters: []platformTypes.IndicatorFilter{
+				{Field: "indicator", Operator: "EQ", Value: "virus1.exe"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, resp.ObjectsCount)
+		assert.Equal(t, "indicator", resp.ObjectsType)
+		require.Len(t, resp.Objects, 1)
+
+		obj := resp.Objects[0]
+		assert.Equal(t, 57, obj.RuleID)
+		assert.Equal(t, "virus1.exe", obj.Indicator)
+		assert.Equal(t, enums.IndicatorTypeFilename, obj.Type)
+		assert.Equal(t, enums.IndicatorSeverityHigh, obj.Severity)
+		assert.Equal(t, int64(-1), obj.ExpirationDate)
+		assert.True(t, obj.DefaultExpirationEnabled)
+		assert.Equal(t, "test", obj.Comment)
+		assert.Equal(t, enums.IndicatorReputationBad, obj.Reputation)
+		assert.Equal(t, enums.IndicatorReliabilityC, obj.Reliability)
+		// Read-only fields (S3 fix):
+		assert.Equal(t, int64(1781000000000), obj.CreationTime)
+		assert.Equal(t, int64(1781000001000), obj.ModificationTime)
+		assert.Equal(t, "ENABLED", obj.Status)
+		assert.Equal(t, "Public API user (key #30)", obj.Source)
+		assert.Equal(t, 7, obj.NumberOfIssues)
+	})
+
+	t.Run("handles JSON null reliability without error", func(t *testing.T) {
+		// Live tenant returns "reliability": null when unset. Go's
+		// encoding/json should map that to the zero value of the
+		// string-aliased enum type ("").
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"objects_count": 1,
+				"objects_type": "indicator",
+				"objects": [{
+					"rule_id": 1,
+					"indicator": "a",
+					"type": "HASH",
+					"severity": "SEV_010_INFO",
+					"reliability": null
+				}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.ListIndicators(context.Background(), platformTypes.ListIndicatorsRequest{})
+		require.NoError(t, err)
+		require.Len(t, resp.Objects, 1)
+		assert.Equal(t, enums.IndicatorReliability(""), resp.Objects[0].Reliability)
+	})
+
+	t.Run("empty result decodes cleanly", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": [], "objects_type": "indicator"}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.ListIndicators(context.Background(), platformTypes.ListIndicatorsRequest{})
+		require.NoError(t, err)
+		assert.Zero(t, resp.ObjectsCount)
+		assert.Empty(t, resp.Objects)
+	})
+}
+
+// --- DeleteIndicators ------------------------------------------------------
+
+func TestClient_DeleteIndicators(t *testing.T) {
+	t.Run("returns deleted rule_ids", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/"+DeleteIndicatorsEndpoint, r.URL.Path)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req indicatorDeleteRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData.Filters, 1)
+			assert.Equal(t, "indicator", req.RequestData.Filters[0].Field)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 2, "objects": [101, 102]}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		ids, err := client.DeleteIndicators(context.Background(), platformTypes.DeleteIndicatorsRequest{
+			Filters: []platformTypes.IndicatorFilter{
+				{Field: "indicator", Operator: "EQ", Value: "evil.example.com"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{101, 102}, ids)
+	})
+
+	t.Run("idempotent: empty filter result is not an error", func(t *testing.T) {
+		// Regression guard for C1: prior to the fix, DeleteIndicators
+		// inspected a non-existent `success` field which was always
+		// false, making this case look like a failure. Now the slice
+		// length alone is the signal.
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": []}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		ids, err := client.DeleteIndicators(context.Background(), platformTypes.DeleteIndicatorsRequest{
+			Filters: []platformTypes.IndicatorFilter{
+				{Field: "indicator", Operator: "EQ", Value: "does-not-exist"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+}
+
+// --- FindIndicatorByName ---------------------------------------------------
+
+func TestClient_FindIndicatorByName(t *testing.T) {
+	t.Run("returns matching record", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req indicatorFilterRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData.Filters, 1)
+			assert.Equal(t, "indicator", req.RequestData.Filters[0].Field)
+			assert.Equal(t, "EQ", req.RequestData.Filters[0].Operator)
+			assert.Equal(t, "evil.example.com", req.RequestData.Filters[0].Value)
+			assert.True(t, req.RequestData.ExtendedView)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"objects_count": 1,
+				"objects": [{"rule_id": 9, "indicator": "evil.example.com", "type": "DOMAIN_NAME", "severity": "SEV_020_LOW"}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindIndicatorByName(context.Background(), "evil.example.com")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 9, got.RuleID)
+		assert.Equal(t, "evil.example.com", got.Indicator)
+	})
+
+	t.Run("returns nil when no match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": [], "objects_type": "indicator"}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindIndicatorByName(context.Background(), "missing")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+
+	t.Run("filters out value mismatches (defensive)", func(t *testing.T) {
+		// The filter is server-evaluated, so in practice this won't fire,
+		// but FindIndicatorByName double-checks the returned object's
+		// `indicator` field. This test pins that contract.
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"objects_count": 1,
+				"objects": [{"rule_id": 1, "indicator": "different-value", "type": "HASH", "severity": "SEV_020_LOW"}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindIndicatorByName(context.Background(), "queried-value")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+// --- FindIndicatorByID -----------------------------------------------------
+
+func TestClient_FindIndicatorByID(t *testing.T) {
+	t.Run("queries by rule_id and returns match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			// The Value carries the int as JSON number; decode into a
+			// loose struct to verify the on-wire type.
+			var raw struct {
+				RequestData struct {
+					Filters []struct {
+						Field    string `json:"field"`
+						Operator string `json:"operator"`
+						Value    any    `json:"value"`
+					} `json:"filters"`
+					ExtendedView bool `json:"extended_view"`
+				} `json:"request_data"`
+			}
+			require.NoError(t, json.Unmarshal(body, &raw))
+			require.Len(t, raw.RequestData.Filters, 1)
+			assert.Equal(t, "rule_id", raw.RequestData.Filters[0].Field)
+			assert.Equal(t, "EQ", raw.RequestData.Filters[0].Operator)
+			// JSON numbers decode to float64 in an `any` field; the
+			// integer payload of 192 round-trips losslessly.
+			assert.Equal(t, float64(192), raw.RequestData.Filters[0].Value)
+			assert.True(t, raw.RequestData.ExtendedView)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"objects_count": 1,
+				"objects": [{"rule_id": 192, "indicator": "x", "type": "URL", "severity": "SEV_050_CRITICAL"}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindIndicatorByID(context.Background(), 192)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 192, got.RuleID)
+		assert.Equal(t, enums.IndicatorTypeURL, got.Type)
+		assert.Equal(t, enums.IndicatorSeverityCritical, got.Severity)
+	})
+
+	t.Run("returns nil when no match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": []}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindIndicatorByID(context.Background(), 999)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}

--- a/types/platform/indicator.go
+++ b/types/platform/indicator.go
@@ -1,0 +1,120 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"github.com/PaloAltoNetworks/cortex-cloud-go/enums"
+)
+
+// ----------------------------------------------------------------------------
+// Indicator (IOC)
+// ----------------------------------------------------------------------------
+
+// Indicator describes a single IOC as accepted by /indicators/insert and
+// returned by /indicators/get.
+//
+// The first nine fields are read+write — the live /indicators/insert
+// endpoint accepts exactly this set (the API explicitly rejects unknown
+// keys with a "The allowed fields are: {...}. Got also the fields: [...]"
+// error). The remaining five fields are read-only: they appear in GET
+// responses but are server-assigned and not part of the insert schema.
+type Indicator struct {
+	// --- Read + Write fields ---
+	RuleID                   int                        `json:"rule_id,omitempty"`
+	Indicator                string                     `json:"indicator"`
+	Type                     enums.IndicatorType        `json:"type"`
+	Severity                 enums.IndicatorSeverity    `json:"severity"`
+	ExpirationDate           int64                      `json:"expiration_date,omitempty"`
+	DefaultExpirationEnabled bool                       `json:"default_expiration_enabled,omitempty"`
+	Comment                  string                     `json:"comment,omitempty"`
+	Reputation               enums.IndicatorReputation  `json:"reputation,omitempty"`
+	Reliability              enums.IndicatorReliability `json:"reliability,omitempty"`
+
+	// --- Read-only fields (server-assigned, returned by /indicators/get) ---
+	CreationTime     int64  `json:"creation_time,omitempty"`
+	ModificationTime int64  `json:"modification_time,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Source           string `json:"source,omitempty"`
+	NumberOfIssues   int    `json:"number_of_issues,omitempty"`
+}
+
+// IndicatorFilter is a single filter expression used by indicators/get and
+// indicators/delete. It is not the generic FilterRoot type because the
+// indicator endpoints accept a flat list of {field, operator, value} entries
+// (no nested AND/OR), and `value` is polymorphic — boolean fields like
+// `default_expiration_enabled` MUST be sent as JSON booleans (sending a
+// string returns HTTP 500); numeric fields like `expiration_date` MUST be
+// integers; everything else passes through as a string.
+type IndicatorFilter struct {
+	Field    string `json:"field"`
+	Operator string `json:"operator"`
+	Value    any    `json:"value"`
+}
+
+// The Cortex `/indicators/insert` endpoint upserts: submit with no
+// `rule_id` to create, or include the existing `rule_id` to overwrite the
+// matching record. The SDK takes a []Indicator slice directly and the
+// internal client wraps it as `{"request_data": [...]}` — there is no
+// dedicated request struct.
+
+// ListIndicatorsRequest is the request body for indicators/get. ExtendedView
+// toggles inclusion of vendor and class fields in the response — though in
+// practice the live API ignores it and returns the same field set either
+// way (vendor/class are not populated for IOCs created via /insert).
+type ListIndicatorsRequest struct {
+	Filters      []IndicatorFilter `json:"filters,omitempty"`
+	ExtendedView bool              `json:"extended_view,omitempty"`
+	SearchFrom   int               `json:"search_from,omitempty"`
+	SearchTo     int               `json:"search_to,omitempty"`
+}
+
+// DeleteIndicatorsRequest is the request body for indicators/delete. The API
+// has no by-ID delete: callers must construct a filter that matches the
+// indicator(s) to remove (typically `{field:"indicator",operator:"EQ",value:<id>}`).
+type DeleteIndicatorsRequest struct {
+	Filters []IndicatorFilter `json:"filters"`
+}
+
+// InsertIndicatorsResponse is returned by /indicators/insert. Created
+// records appear in AddedObjects; overwritten records appear in
+// UpdatedObjects. Per-record failures appear in Errors keyed by the
+// original index inside the batch — Errors items are objects, not strings,
+// despite what the OpenAPI spec for /insert claims.
+type InsertIndicatorsResponse struct {
+	AddedObjects   []IndicatorInsertResult `json:"added_objects,omitempty"`
+	UpdatedObjects []IndicatorInsertResult `json:"updated_objects,omitempty"`
+	Errors         []IndicatorInsertError  `json:"errors,omitempty"`
+}
+
+// IndicatorInsertResult is one entry inside AddedObjects/UpdatedObjects
+// from /indicators/insert. ID is the server-assigned rule_id; Status is a
+// human-readable message describing what was done.
+type IndicatorInsertResult struct {
+	ID     int    `json:"id"`
+	Status string `json:"status"`
+}
+
+// IndicatorInsertError is one entry inside Errors from /indicators/insert.
+// Index is the zero-based position of the failing record inside the
+// original request batch; Status is the server-supplied failure reason.
+type IndicatorInsertError struct {
+	Index  int    `json:"index"`
+	Status string `json:"status"`
+}
+
+// ListIndicatorsResponse is returned by /indicators/get.
+type ListIndicatorsResponse struct {
+	ObjectsCount int         `json:"objects_count"`
+	ObjectsType  string      `json:"objects_type"`
+	Objects      []Indicator `json:"objects"`
+}
+
+// DeleteIndicatorsResponse is returned by /indicators/delete. Objects
+// carries the server-assigned rule_ids that were removed; ObjectsCount is
+// the length of that slice. Delete is idempotent — deleting a non-existent
+// indicator returns `{objects_count: 0, objects: []}` with no error.
+type DeleteIndicatorsResponse struct {
+	ObjectsCount int   `json:"objects_count"`
+	Objects      []int `json:"objects"`
+}


### PR DESCRIPTION
## Summary

Adds first-class support for `/public_api/v1/indicators/{insert,get,delete}` to the platform module:

- New `Indicator` and `IndicatorFilter` types with the nine write-allowed fields plus five read-only fields the live API returns (`creation_time`, `modification_time`, `status`, `source`, `number_of_issues`).
- New `Client.InsertIndicators` (upsert via `rule_id`), `Client.ListIndicators`, `Client.DeleteIndicators`, and convenience helpers `Client.FindIndicatorByName` / `Client.FindIndicatorByID`.
- New `enums` package additions: `IndicatorType`, `IndicatorSeverity`, `IndicatorReputation`, `IndicatorReliability` (string-aliased) with canonical-set helpers. Includes `URL` and `SEV_050_CRITICAL`, which the live API accepts even though the OpenAPI insert enums omit them.

## Test plan

- [x] `go test ./platform/...` — 15 unit sub-tests covering the three endpoints, the structured `errors[{index,status}]` shape, the no-`reply` wrapper on success, JSON-`null` `reliability`, and both `FindIndicatorBy*` helpers.
- [x] `go test -tags=acceptance -run TestAccIndicator ./platform/...` — four lifecycle / URL+critical-severity / idempotent-delete / boolean-filter tests against a live tenant; all green, tenant left clean.
- [x] `go vet ./platform/... ./types/... ./enums/...` clean.