### PR TITLE
feat(platform): add BIOC support

### DIFF
--- a/enums/bioc.go
+++ b/enums/bioc.go
@@ -1,0 +1,123 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package enums
+
+// ==============================================================================
+// BIOC Enums
+// ==============================================================================
+//
+// Mirrors the enum sets declared by the `/public_api/v1/bioc/insert` schema.
+// Underlying Go type is `string`, so callers can hold any value the API
+// surfaces — including ones the OpenAPI spec doesn't yet document — but the
+// named constants are the documented set and should be used as the default.
+
+// ----------------------------------------------------------------------------
+// BIOC Type
+// ----------------------------------------------------------------------------
+
+// BIOCType is the category a BIOC rule falls under. The 16 values mirror the
+// `/public_api/v1/bioc/insert` request schema and match the casing the live
+// API returns on GET.
+type BIOCType string
+
+const (
+	BIOCTypeOther                    BIOCType = "OTHER"
+	BIOCTypePersistence              BIOCType = "PERSISTENCE"
+	BIOCTypeEvasion                  BIOCType = "EVASION"
+	BIOCTypeTampering                BIOCType = "TAMPERING"
+	BIOCTypeFileTypeObfuscation      BIOCType = "FILE_TYPE_OBFUSCATION"
+	BIOCTypePrivilegeEscalation      BIOCType = "PRIVILEGE_ESCALATION"
+	BIOCTypeCredentialAccess         BIOCType = "CREDENTIAL_ACCESS"
+	BIOCTypeLateralMovement          BIOCType = "LATERAL_MOVEMENT"
+	BIOCTypeExecution                BIOCType = "EXECUTION"
+	BIOCTypeCollection               BIOCType = "COLLECTION"
+	BIOCTypeExfiltration             BIOCType = "EXFILTRATION"
+	BIOCTypeInfiltration             BIOCType = "INFILTRATION"
+	BIOCTypeDropper                  BIOCType = "DROPPER"
+	BIOCTypeFilePrivilegeManipulation BIOCType = "FILE_PRIVILEGE_MANIPULATION"
+	BIOCTypeReconnaissance           BIOCType = "RECONNAISSANCE"
+	BIOCTypeDiscovery                BIOCType = "DISCOVERY"
+)
+
+// BIOCTypes returns the documented BIOCType values in declaration order.
+func BIOCTypes() []BIOCType {
+	return []BIOCType{
+		BIOCTypeOther,
+		BIOCTypePersistence,
+		BIOCTypeEvasion,
+		BIOCTypeTampering,
+		BIOCTypeFileTypeObfuscation,
+		BIOCTypePrivilegeEscalation,
+		BIOCTypeCredentialAccess,
+		BIOCTypeLateralMovement,
+		BIOCTypeExecution,
+		BIOCTypeCollection,
+		BIOCTypeExfiltration,
+		BIOCTypeInfiltration,
+		BIOCTypeDropper,
+		BIOCTypeFilePrivilegeManipulation,
+		BIOCTypeReconnaissance,
+		BIOCTypeDiscovery,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// BIOC Severity
+// ----------------------------------------------------------------------------
+
+// BIOCSeverity is the severity rating assigned to a BIOC. The namespaced
+// `SEV_NNN_X` encoding matches the live API.
+//
+// Note: SEV_050_CRITICAL is omitted from the OpenAPI severity enum for
+// /bioc/insert but is present in the Cortex UI and accepted by the live
+// API — verified by inserting a record with severity=SEV_050_CRITICAL on
+// a live tenant and round-tripping it via /bioc/get. Same behavior as
+// IndicatorSeverity.
+type BIOCSeverity string
+
+const (
+	BIOCSeverityInfo     BIOCSeverity = "SEV_010_INFO"
+	BIOCSeverityLow      BIOCSeverity = "SEV_020_LOW"
+	BIOCSeverityMedium   BIOCSeverity = "SEV_030_MEDIUM"
+	BIOCSeverityHigh     BIOCSeverity = "SEV_040_HIGH"
+	BIOCSeverityCritical BIOCSeverity = "SEV_050_CRITICAL"
+)
+
+// BIOCSeverities returns the BIOCSeverity values accepted by the live API.
+// SEV_050_CRITICAL is included despite being missing from the OpenAPI spec.
+func BIOCSeverities() []BIOCSeverity {
+	return []BIOCSeverity{
+		BIOCSeverityInfo,
+		BIOCSeverityLow,
+		BIOCSeverityMedium,
+		BIOCSeverityHigh,
+		BIOCSeverityCritical,
+	}
+}
+
+// ----------------------------------------------------------------------------
+// BIOC Status
+// ----------------------------------------------------------------------------
+
+// BIOCStatus toggles whether a BIOC rule is active. The OpenAPI schema
+// declares the enum in lowercase (`enabled`/`disabled`), and the live API
+// preserves whatever casing was written — records created via the UI come
+// back uppercase, records inserted via the SDK in lowercase come back
+// lowercase. Callers comparing status should normalize first; the SDK
+// constants are the lowercase canonical form.
+type BIOCStatus string
+
+const (
+	BIOCStatusEnabled  BIOCStatus = "enabled"
+	BIOCStatusDisabled BIOCStatus = "disabled"
+)
+
+// BIOCStatuses returns the documented BIOCStatus values in declaration
+// order.
+func BIOCStatuses() []BIOCStatus {
+	return []BIOCStatus{
+		BIOCStatusEnabled,
+		BIOCStatusDisabled,
+	}
+}

--- a/platform/biocs.go
+++ b/platform/biocs.go
@@ -1,0 +1,121 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/PaloAltoNetworks/cortex-cloud-go/internal/client"
+	types "github.com/PaloAltoNetworks/cortex-cloud-go/types/platform"
+)
+
+// InsertBIOCs uploads one or more BIOCs. The endpoint upserts: submit a
+// payload with no `rule_id` to create a new record, or include the
+// server-assigned `rule_id` for an existing record to overwrite it.
+// Per-record failures surface in Errors[] keyed by the original batch
+// position; successful creates/updates appear in AddedObjects/UpdatedObjects.
+//
+// Unlike /indicators/insert, /bioc/insert returns HTTP 400 (not 200) when
+// any single record fails validation, but the body still uses the success
+// shape (added_objects/updated_objects/errors). This helper recovers the
+// typed response from that body and returns (resp, nil) so callers can
+// inspect resp.Errors without first handling an HTTP error. True transport-
+// level failures (no body, malformed body, auth, etc.) still surface as a
+// non-nil error from mapError. Verified against a live tenant.
+func (c *Client) InsertBIOCs(ctx context.Context, biocs []types.BIOC) (types.InsertBIOCsResponse, error) {
+	var resp types.InsertBIOCsResponse
+	body, err := c.internalClient.Do(ctx, http.MethodPost, InsertBIOCsEndpoint, nil, nil, biocs, &resp, &client.DoOptions{
+		RequestWrapperKeys: []string{"request_data"},
+	})
+	if err == nil {
+		return resp, nil
+	}
+	// Recover the success-shape body that /bioc/insert returns on per-
+	// record validation failures. If the body parses and contains any of
+	// the expected fields, surface it instead of the HTTP-level error.
+	var recovered types.InsertBIOCsResponse
+	if jsonErr := json.Unmarshal(body, &recovered); jsonErr == nil {
+		if len(recovered.Errors) > 0 || len(recovered.AddedObjects) > 0 || len(recovered.UpdatedObjects) > 0 {
+			return recovered, nil
+		}
+	}
+	return resp, mapError(err)
+}
+
+// ListBIOCs retrieves BIOCs matching the provided filter set. Pass an empty
+// Filters slice to list all BIOCs (capped by the server).
+func (c *Client) ListBIOCs(ctx context.Context, req types.ListBIOCsRequest) (types.ListBIOCsResponse, error) {
+	var resp types.ListBIOCsResponse
+	_, err := c.internalClient.Do(ctx, http.MethodPost, ListBIOCsEndpoint, nil, nil, req, &resp, &client.DoOptions{
+		RequestWrapperKeys: []string{"request_data"},
+	})
+	return resp, mapError(err)
+}
+
+// DeleteBIOCs removes BIOCs matching the provided filter set and returns
+// the server-assigned rule_ids of the removed records. The API has no by-ID
+// delete; identity is carried in the filter body. Callers managing a single
+// BIOC by rule_id should pass `{field:"rule_id",operator:"EQ",value:<id>}`
+// — `rule_id` is undocumented in the OpenAPI filter enum but accepted by
+// the live API (verified against a live tenant). Deleting by
+// `name` is unsafe because BIOC names are not unique per tenant.
+//
+// An empty returned slice means the filter matched nothing — callers that
+// treat "delete on a missing record" as success should ignore the count.
+func (c *Client) DeleteBIOCs(ctx context.Context, req types.DeleteBIOCsRequest) ([]int, error) {
+	var resp types.DeleteBIOCsResponse
+	_, err := c.internalClient.Do(ctx, http.MethodPost, DeleteBIOCsEndpoint, nil, nil, req, &resp, &client.DoOptions{
+		RequestWrapperKeys: []string{"request_data"},
+	})
+	return resp.Objects, mapError(err)
+}
+
+// FindBIOCByID returns the BIOC whose server-assigned `rule_id` equals the
+// given value, or nil if no match was found. The OpenAPI lists `rule_id`
+// only in the bioc/get *example*, not in the documented filter-field enum,
+// but the live API accepts it on EQ. Use this as the primary lookup path —
+// BIOC names are not unique per tenant, so FindBIOCByName is unsafe for
+// stateful flows.
+func (c *Client) FindBIOCByID(ctx context.Context, ruleID int) (*types.BIOC, error) {
+	resp, err := c.ListBIOCs(ctx, types.ListBIOCsRequest{
+		ExtendedView: true,
+		Filters: []types.BIOCFilter{
+			{Field: "rule_id", Operator: "EQ", Value: ruleID},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.Objects {
+		if resp.Objects[i].RuleID == ruleID {
+			return &resp.Objects[i], nil
+		}
+	}
+	return nil, nil
+}
+
+// FindBIOCByName returns the FIRST BIOC whose `name` equals the given
+// value, or nil if no match was found. BIOC names are not unique on a
+// tenant: two BIOCs may share the same name with distinct rule_ids. This
+// helper is useful for ad-hoc CLI lookups but unsafe for stateful flows —
+// use FindBIOCByID once you know the rule_id.
+func (c *Client) FindBIOCByName(ctx context.Context, name string) (*types.BIOC, error) {
+	resp, err := c.ListBIOCs(ctx, types.ListBIOCsRequest{
+		ExtendedView: true,
+		Filters: []types.BIOCFilter{
+			{Field: "name", Operator: "EQ", Value: name},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	for i := range resp.Objects {
+		if resp.Objects[i].Name == name {
+			return &resp.Objects[i], nil
+		}
+	}
+	return nil, nil
+}

--- a/platform/biocs_acc_test.go
+++ b/platform/biocs_acc_test.go
@@ -1,0 +1,316 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+//go:build acceptance
+
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/PaloAltoNetworks/cortex-cloud-go/enums"
+	platformTypes "github.com/PaloAltoNetworks/cortex-cloud-go/types/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccBIOCLifecycle exercises the full create→read→update→delete path
+// against a live tenant. Configure via the same env vars used by the
+// asset-group and indicator acceptance tests: TEST_CORTEX_API_URL,
+// TEST_CORTEX_API_KEY, TEST_CORTEX_API_KEY_ID. Run with:
+//
+//	go test -tags=acceptance -run TestAccBIOC -v ./platform/...
+func TestAccBIOCLifecycle(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	biocName := fmt.Sprintf("go-sdk-acctest-bioc-%s", timestamp)
+	xqlBody, err := json.Marshal(fmt.Sprintf(
+		"dataset = xdr_data | filter event_type = 1 and actor_process_image_name = \"acctest-%s.exe\"",
+		timestamp,
+	))
+	require.NoError(t, err)
+
+	original := platformTypes.BIOC{
+		Name:                    biocName,
+		Type:                    enums.BIOCTypeExecution,
+		Severity:                enums.BIOCSeverityLow,
+		Status:                  enums.BIOCStatusEnabled,
+		Comment:                 fmt.Sprintf("go-sdk acceptance test %s", timestamp),
+		IsXQL:                   true,
+		Indicator:               json.RawMessage(xqlBody),
+		MitreTacticIDAndName:    []string{},
+		MitreTechniqueIDAndName: []string{},
+	}
+
+	// --- Create ---
+	insertResp, err := client.InsertBIOCs(ctx, []platformTypes.BIOC{original})
+	require.NoError(t, err, "InsertBIOCs (create) failed")
+	require.Empty(t, insertResp.Errors, "unexpected per-record errors: %v", insertResp.Errors)
+	require.Len(t, insertResp.AddedObjects, 1, "expected one added record")
+	require.Empty(t, insertResp.UpdatedObjects, "create path should not populate updated_objects")
+	ruleID := insertResp.AddedObjects[0].ID
+	assert.Positive(t, ruleID)
+	assert.Contains(t, insertResp.AddedObjects[0].Status, "Created")
+
+	// Defer cleanup as early as possible.
+	defer func() {
+		ids, delErr := client.DeleteBIOCs(ctx, platformTypes.DeleteBIOCsRequest{
+			Filters: []platformTypes.BIOCFilter{
+				{Field: "rule_id", Operator: "EQ", Value: ruleID},
+			},
+		})
+		if delErr != nil {
+			t.Logf("cleanup delete failed: %s", delErr.Error())
+		}
+		t.Logf("cleanup removed rule_ids: %v", ids)
+	}()
+
+	// --- Read by ID ---
+	// rule_id filter on /bioc/get is undocumented in the OpenAPI field
+	// enum but accepted by the live API on EQ. This sub-assertion is the
+	// canonical regression guard.
+	byID, err := client.FindBIOCByID(ctx, ruleID)
+	require.NoError(t, err, "FindBIOCByID failed")
+	require.NotNil(t, byID, "rule_id lookup should succeed")
+	assert.Equal(t, ruleID, byID.RuleID)
+	assert.Equal(t, biocName, byID.Name)
+	assert.Equal(t, enums.BIOCTypeExecution, byID.Type)
+	assert.Equal(t, enums.BIOCSeverityLow, byID.Severity)
+	assert.True(t, byID.IsXQL)
+	assert.Positive(t, byID.CreationTime, "creation_time should be set")
+	assert.Positive(t, byID.ModificationTime, "modification_time should be set")
+	assert.NotEmpty(t, byID.Source, "source should be set")
+
+	// --- Read by name ---
+	byName, err := client.FindBIOCByName(ctx, biocName)
+	require.NoError(t, err, "FindBIOCByName failed")
+	require.NotNil(t, byName, "BIOC should exist after insert")
+	assert.Equal(t, ruleID, byName.RuleID)
+
+	// --- Update via upsert (rule_id-keyed overwrite) ---
+	updated := original
+	updated.RuleID = ruleID
+	updated.Name = biocName + "-renamed" // rename in place: should keep rule_id
+	updated.Severity = enums.BIOCSeverityHigh
+	updated.Comment = original.Comment + " (updated)"
+
+	updateResp, err := client.InsertBIOCs(ctx, []platformTypes.BIOC{updated})
+	require.NoError(t, err, "InsertBIOCs (update) failed")
+	require.Empty(t, updateResp.Errors, "unexpected per-record errors on update: %v", updateResp.Errors)
+	require.Empty(t, updateResp.AddedObjects, "update path should not populate added_objects")
+	require.Len(t, updateResp.UpdatedObjects, 1, "expected one updated record")
+	assert.Equal(t, ruleID, updateResp.UpdatedObjects[0].ID)
+	assert.Contains(t, updateResp.UpdatedObjects[0].Status, "Updated")
+
+	// Confirm new content lands on read-back.
+	afterUpdate, err := client.FindBIOCByID(ctx, ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, afterUpdate)
+	assert.Equal(t, ruleID, afterUpdate.RuleID, "rule_id should be stable across in-place updates")
+	assert.Equal(t, updated.Name, afterUpdate.Name, "name should be mutable via rule_id-keyed upsert")
+	assert.Equal(t, enums.BIOCSeverityHigh, afterUpdate.Severity)
+	assert.Equal(t, updated.Comment, afterUpdate.Comment)
+	assert.GreaterOrEqual(t, afterUpdate.ModificationTime, byID.ModificationTime,
+		"modification_time should be non-decreasing after an update")
+
+	// --- Delete by rule_id ---
+	deleted, err := client.DeleteBIOCs(ctx, platformTypes.DeleteBIOCsRequest{
+		Filters: []platformTypes.BIOCFilter{
+			{Field: "rule_id", Operator: "EQ", Value: ruleID},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, deleted, 1, "expected exactly one record removed")
+	assert.Equal(t, ruleID, deleted[0])
+
+	// Confirm gone.
+	gone, err := client.FindBIOCByID(ctx, ruleID)
+	require.NoError(t, err)
+	assert.Nil(t, gone, "BIOC should be absent after delete")
+}
+
+// TestAccBIOCIdempotentDelete pins the empty-result-no-error contract:
+// /bioc/delete returns `{objects_count: 0, objects: []}` (no error) when
+// the filter matches nothing.
+func TestAccBIOCIdempotentDelete(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+
+	ids, err := client.DeleteBIOCs(ctx, platformTypes.DeleteBIOCsRequest{
+		Filters: []platformTypes.BIOCFilter{
+			{Field: "rule_id", Operator: "EQ", Value: 999999999},
+		},
+	})
+	require.NoError(t, err, "deleting a non-existent BIOC should not error")
+	assert.Empty(t, ids, "expected zero rule_ids returned for missing record")
+}
+
+// TestAccBIOCStructuredIndicator verifies the non-XQL form: the indicator
+// field is a JSON object describing a filter AST. The structured form is
+// what the Cortex UI emits when users build a BIOC via the visual editor.
+func TestAccBIOCStructuredIndicator(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	biocName := fmt.Sprintf("go-sdk-acctest-bioc-structured-%s", timestamp)
+	indicator, err := json.Marshal(map[string]any{
+		"runOnCGO":          true,
+		"investigationType": "PROCESS_EXECUTION_EVENT",
+		"investigation": map[string]any{
+			"PROCESS_EXECUTION_EVENT": map[string]any{
+				"filter": map[string]any{
+					"AND": []map[string]any{
+						{
+							"SEARCH_FIELD": "action_process_username",
+							"SEARCH_TYPE":  "EQ",
+							"SEARCH_VALUE": fmt.Sprintf("acctest-%s", timestamp),
+							"EXTRA_FIELDS": []any{},
+							"isExtended":   false,
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resp, err := client.InsertBIOCs(ctx, []platformTypes.BIOC{{
+		Name:                    biocName,
+		Type:                    enums.BIOCTypeExecution,
+		Severity:                enums.BIOCSeverityInfo,
+		Status:                  enums.BIOCStatusDisabled,
+		Comment:                 "structured-indicator acceptance probe — safe to delete",
+		IsXQL:                   false,
+		Indicator:               json.RawMessage(indicator),
+		MitreTacticIDAndName:    []string{},
+		MitreTechniqueIDAndName: []string{},
+	}})
+	require.NoError(t, err)
+	require.Empty(t, resp.Errors, "structured indicator should be accepted: %v", resp.Errors)
+	require.Len(t, resp.AddedObjects, 1)
+	ruleID := resp.AddedObjects[0].ID
+
+	defer func() {
+		_, _ = client.DeleteBIOCs(ctx, platformTypes.DeleteBIOCsRequest{
+			Filters: []platformTypes.BIOCFilter{
+				{Field: "rule_id", Operator: "EQ", Value: ruleID},
+			},
+		})
+	}()
+
+	got, err := client.FindBIOCByID(ctx, ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.False(t, got.IsXQL)
+
+	// The indicator round-trips as a JSON object — decode and verify a
+	// nested field survived.
+	var obj map[string]any
+	require.NoError(t, json.Unmarshal(got.Indicator, &obj))
+	assert.Equal(t, "PROCESS_EXECUTION_EVENT", obj["investigationType"])
+}
+
+// TestAccBIOCSeverityCritical verifies that SEV_050_CRITICAL is accepted by
+// /bioc/insert and round-trips via /bioc/get even though the OpenAPI
+// severity enum tops at SEV_040_HIGH. Mirrors TestAccIndicatorURLType for
+// IndicatorSeverityCritical.
+func TestAccBIOCSeverityCritical(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	biocName := fmt.Sprintf("go-sdk-acctest-bioc-critical-%s", timestamp)
+	xqlBody, err := json.Marshal(fmt.Sprintf(
+		"dataset = xdr_data | filter event_type = 1 and actor_process_image_name = \"acctest-critical-%s.exe\"",
+		timestamp,
+	))
+	require.NoError(t, err)
+
+	resp, err := client.InsertBIOCs(ctx, []platformTypes.BIOC{{
+		Name:                    biocName,
+		Type:                    enums.BIOCTypeExecution,
+		Severity:                enums.BIOCSeverityCritical,
+		Status:                  enums.BIOCStatusDisabled,
+		Comment:                 "SEV_050_CRITICAL acceptance probe — safe to delete",
+		IsXQL:                   true,
+		Indicator:               json.RawMessage(xqlBody),
+		MitreTacticIDAndName:    []string{},
+		MitreTechniqueIDAndName: []string{},
+	}})
+	require.NoError(t, err)
+	require.Empty(t, resp.Errors, "SEV_050_CRITICAL should be accepted: %v", resp.Errors)
+	require.Len(t, resp.AddedObjects, 1)
+	ruleID := resp.AddedObjects[0].ID
+
+	defer func() {
+		_, _ = client.DeleteBIOCs(ctx, platformTypes.DeleteBIOCsRequest{
+			Filters: []platformTypes.BIOCFilter{
+				{Field: "rule_id", Operator: "EQ", Value: ruleID},
+			},
+		})
+	}()
+
+	got, err := client.FindBIOCByID(ctx, ruleID)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, enums.BIOCSeverityCritical, got.Severity, "SEV_050_CRITICAL should round-trip via /bioc/get")
+}
+
+// TestAccBIOCNonUniqueNames pins the verified-against-live-tenant fact that
+// BIOC names are NOT unique per tenant: two BIOCs with the same name
+// produce two distinct rule_ids. This is the foundational invariant the
+// terraform-provider-cortexcloud BIOC resource relies on for its
+// rule_id-as-identity design.
+func TestAccBIOCNonUniqueNames(t *testing.T) {
+	client := setupAcceptanceTest(t)
+	ctx := context.Background()
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+
+	biocName := fmt.Sprintf("go-sdk-acctest-bioc-shared-%s", timestamp)
+	xqlA, _ := json.Marshal(fmt.Sprintf("dataset = xdr_data | filter event_type = 1 and actor_process_image_name = \"acctest-a-%s.exe\"", timestamp))
+	xqlB, _ := json.Marshal(fmt.Sprintf("dataset = xdr_data | filter event_type = 1 and actor_process_image_name = \"acctest-b-%s.exe\"", timestamp))
+
+	mkBIOC := func(body []byte) platformTypes.BIOC {
+		return platformTypes.BIOC{
+			Name:                    biocName,
+			Type:                    enums.BIOCTypeExecution,
+			Severity:                enums.BIOCSeverityInfo,
+			Status:                  enums.BIOCStatusDisabled,
+			Comment:                 "non-unique-name acceptance probe — safe to delete",
+			IsXQL:                   true,
+			Indicator:               json.RawMessage(body),
+			MitreTacticIDAndName:    []string{},
+			MitreTechniqueIDAndName: []string{},
+		}
+	}
+
+	respA, err := client.InsertBIOCs(ctx, []platformTypes.BIOC{mkBIOC(xqlA)})
+	require.NoError(t, err)
+	require.Len(t, respA.AddedObjects, 1)
+	idA := respA.AddedObjects[0].ID
+
+	respB, err := client.InsertBIOCs(ctx, []platformTypes.BIOC{mkBIOC(xqlB)})
+	require.NoError(t, err)
+	require.Len(t, respB.AddedObjects, 1)
+	idB := respB.AddedObjects[0].ID
+
+	defer func() {
+		for _, id := range []int{idA, idB} {
+			_, _ = client.DeleteBIOCs(ctx, platformTypes.DeleteBIOCsRequest{
+				Filters: []platformTypes.BIOCFilter{
+					{Field: "rule_id", Operator: "EQ", Value: id},
+				},
+			})
+		}
+	}()
+
+	assert.NotEqual(t, idA, idB, "two BIOCs with the same name must get distinct rule_ids")
+}

--- a/platform/biocs_test.go
+++ b/platform/biocs_test.go
@@ -1,0 +1,506 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package platform
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/PaloAltoNetworks/cortex-cloud-go/enums"
+	platformTypes "github.com/PaloAltoNetworks/cortex-cloud-go/types/platform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- helpers ---------------------------------------------------------------
+
+// biocInsertRequest mirrors the body shape /bioc/insert expects:
+// `{ "request_data": [<BIOC>, ...] }`.
+type biocInsertRequest struct {
+	RequestData []platformTypes.BIOC `json:"request_data"`
+}
+
+// biocFilterRequest mirrors /bioc/get and /bioc/delete:
+// `{ "request_data": { "filters": [...], ... } }`.
+type biocFilterRequest struct {
+	RequestData platformTypes.ListBIOCsRequest `json:"request_data"`
+}
+
+// biocDeleteRequest mirrors the delete body.
+type biocDeleteRequest struct {
+	RequestData platformTypes.DeleteBIOCsRequest `json:"request_data"`
+}
+
+// xqlIndicator wraps a raw XQL string as the JSON value /bioc/insert expects
+// when is_xql=true. The endpoint accepts the indicator field as either a
+// string (XQL) or an object (filter AST); the SDK keeps it as a
+// json.RawMessage so callers can pass either.
+func xqlIndicator(query string) json.RawMessage {
+	b, _ := json.Marshal(query)
+	return json.RawMessage(b)
+}
+
+// structuredIndicator returns a minimal filter-AST indicator object.
+func structuredIndicator(t *testing.T) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(map[string]any{
+		"runOnCGO":          true,
+		"investigationType": "PROCESS_EXECUTION_EVENT",
+		"investigation": map[string]any{
+			"PROCESS_EXECUTION_EVENT": map[string]any{
+				"filter": map[string]any{
+					"AND": []map[string]any{
+						{
+							"SEARCH_FIELD": "action_process_username",
+							"SEARCH_TYPE":  "EQ",
+							"SEARCH_VALUE": "test",
+							"EXTRA_FIELDS": []any{},
+							"isExtended":   false,
+						},
+					},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	return json.RawMessage(b)
+}
+
+// --- InsertBIOCs -----------------------------------------------------------
+
+func TestClient_InsertBIOCs(t *testing.T) {
+	t.Run("create returns added_objects with new rule_id", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/"+InsertBIOCsEndpoint, r.URL.Path)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var req biocInsertRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData, 1)
+			assert.Equal(t, "test-bioc", req.RequestData[0].Name)
+			assert.Equal(t, enums.BIOCTypeExecution, req.RequestData[0].Type)
+			assert.Equal(t, enums.BIOCSeverityLow, req.RequestData[0].Severity)
+			// rule_id is omitempty and absent on create.
+			assert.Zero(t, req.RequestData[0].RuleID)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [{"id": 42, "status": "Created a new bioc with the ID: 42 successfully"}],
+				"updated_objects": [],
+				"errors": []
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertBIOCs(context.Background(), []platformTypes.BIOC{
+			{
+				Name:      "test-bioc",
+				Type:      enums.BIOCTypeExecution,
+				Severity:  enums.BIOCSeverityLow,
+				Status:    enums.BIOCStatusEnabled,
+				IsXQL:     true,
+				Indicator: xqlIndicator("dataset = xdr_data | filter event_type = 1"),
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.AddedObjects, 1)
+		assert.Equal(t, 42, resp.AddedObjects[0].ID)
+		assert.Contains(t, resp.AddedObjects[0].Status, "Created")
+		assert.Empty(t, resp.UpdatedObjects)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("update returns updated_objects when rule_id is supplied", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var req biocInsertRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData, 1)
+			assert.Equal(t, 42, req.RequestData[0].RuleID)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [],
+				"updated_objects": [{"id": 42, "status": "Updated a bioc with the ID: 42 successfully"}],
+				"errors": []
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertBIOCs(context.Background(), []platformTypes.BIOC{
+			{
+				RuleID:    42,
+				Name:      "renamed-bioc",
+				Type:      enums.BIOCTypeExecution,
+				Severity:  enums.BIOCSeverityLow,
+				Status:    enums.BIOCStatusEnabled,
+				IsXQL:     true,
+				Indicator: xqlIndicator("dataset = xdr_data | filter event_type = 1"),
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.UpdatedObjects, 1)
+		assert.Equal(t, 42, resp.UpdatedObjects[0].ID)
+		assert.Empty(t, resp.AddedObjects)
+		assert.Empty(t, resp.Errors)
+	})
+
+	t.Run("HTTP 400 with success-shape body recovers errors[] as typed response", func(t *testing.T) {
+		// Regression guard: per-record validation failures on /bioc/insert
+		// return HTTP 400 with the success body shape. InsertBIOCs must
+		// re-parse the body and surface resp.Errors with no Go error.
+		// Verified against a live tenant.
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{
+				"added_objects": [],
+				"updated_objects": [],
+				"errors": [{"index": 0, "status": "Failed to create bioc due to: Missing the fields: ['comment']"}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertBIOCs(context.Background(), []platformTypes.BIOC{{
+			Name: "bad", Type: enums.BIOCTypeExecution, Severity: enums.BIOCSeverityLow,
+		}})
+		require.NoError(t, err, "per-record errors on 400 should NOT surface as a Go error")
+		require.Len(t, resp.Errors, 1)
+		assert.Equal(t, 0, resp.Errors[0].Index)
+		assert.Contains(t, resp.Errors[0].Status, "Missing the fields")
+		assert.Empty(t, resp.AddedObjects)
+		assert.Empty(t, resp.UpdatedObjects)
+	})
+
+	t.Run("HTTP 200 with errors are decoded as {index,status} objects", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [],
+				"updated_objects": [],
+				"errors": [{"index": 1, "status": "Failed to create bioc due to: Invalid type"}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertBIOCs(context.Background(), []platformTypes.BIOC{{Name: "x"}})
+		require.NoError(t, err)
+		require.Len(t, resp.Errors, 1)
+		assert.Equal(t, 1, resp.Errors[0].Index)
+		assert.Contains(t, resp.Errors[0].Status, "Invalid type")
+	})
+
+	t.Run("transport-level errors still surface", func(t *testing.T) {
+		// Non-recoverable HTTP errors (e.g. 401 with reply-wrapped body)
+		// should not be silently swallowed by the 400-recovery path.
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+			fmt.Fprint(w, `{"reply":{"err_code":401,"err_msg":"Unauthorized","err_extra":""}}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		_, err := client.InsertBIOCs(context.Background(), []platformTypes.BIOC{{Name: "x"}})
+		require.Error(t, err)
+	})
+
+	t.Run("success body is read at top level (no reply wrapper)", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"added_objects": [{"id": 1, "status": "ok"}],
+				"updated_objects": [],
+				"errors": []
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertBIOCs(context.Background(), []platformTypes.BIOC{{
+			Name: "x", Type: enums.BIOCTypeExecution, Severity: enums.BIOCSeverityLow,
+		}})
+		require.NoError(t, err)
+		require.Len(t, resp.AddedObjects, 1)
+		assert.Equal(t, 1, resp.AddedObjects[0].ID)
+	})
+
+	t.Run("polymorphic indicator: object payload passes through", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req biocInsertRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData, 1)
+			// The Indicator field should round-trip as a JSON object,
+			// not a JSON string. Decode as map and probe a field.
+			var obj map[string]any
+			require.NoError(t, json.Unmarshal(req.RequestData[0].Indicator, &obj))
+			assert.Equal(t, "PROCESS_EXECUTION_EVENT", obj["investigationType"])
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"added_objects": [{"id": 7, "status": "Created"}], "updated_objects": [], "errors": []}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.InsertBIOCs(context.Background(), []platformTypes.BIOC{{
+			Name: "structured", Type: enums.BIOCTypeExecution, Severity: enums.BIOCSeverityLow,
+			Status: enums.BIOCStatusEnabled, IsXQL: false, Indicator: structuredIndicator(t),
+		}})
+		require.NoError(t, err)
+		require.Len(t, resp.AddedObjects, 1)
+	})
+}
+
+// --- ListBIOCs -------------------------------------------------------------
+
+func TestClient_ListBIOCs(t *testing.T) {
+	t.Run("returns objects with read-only fields populated", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/"+ListBIOCsEndpoint, r.URL.Path)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req biocFilterRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			assert.True(t, req.RequestData.ExtendedView)
+			require.Len(t, req.RequestData.Filters, 1)
+			assert.Equal(t, "name", req.RequestData.Filters[0].Field)
+			assert.Equal(t, "EQ", req.RequestData.Filters[0].Operator)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"objects_count": 1,
+				"objects_type": "bioc",
+				"objects": [{
+					"rule_id": 57,
+					"name": "test",
+					"type": "EXECUTION",
+					"severity": "SEV_040_HIGH",
+					"status": "ENABLED",
+					"comment": "audit",
+					"is_xql": true,
+					"indicator": "dataset = xdr_data | filter event_type = 1",
+					"mitre_tactic_id_and_name": ["TA0001 - Initial Access"],
+					"mitre_technique_id_and_name": ["T1059 - Command and Scripting Interpreter"],
+					"creation_time": 1781000000000,
+					"modification_time": 1781000001000,
+					"source": "Public API user (key #30)",
+					"number_of_issues": 7
+				}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.ListBIOCs(context.Background(), platformTypes.ListBIOCsRequest{
+			ExtendedView: true,
+			Filters: []platformTypes.BIOCFilter{
+				{Field: "name", Operator: "EQ", Value: "test"},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, resp.ObjectsCount)
+		assert.Equal(t, "bioc", resp.ObjectsType)
+		require.Len(t, resp.Objects, 1)
+
+		obj := resp.Objects[0]
+		assert.Equal(t, 57, obj.RuleID)
+		assert.Equal(t, "test", obj.Name)
+		assert.Equal(t, enums.BIOCTypeExecution, obj.Type)
+		assert.Equal(t, enums.BIOCSeverityHigh, obj.Severity)
+		// Status is server-preserved: pre-existing tenant records may
+		// come back uppercase. Callers normalize for comparison.
+		assert.Equal(t, enums.BIOCStatus("ENABLED"), obj.Status)
+		assert.True(t, obj.IsXQL)
+		// Indicator decodes to a JSON string for XQL — keep the surrounding quotes.
+		assert.Equal(t, `"dataset = xdr_data | filter event_type = 1"`, string(obj.Indicator))
+		// Read-only fields:
+		assert.Equal(t, int64(1781000000000), obj.CreationTime)
+		assert.Equal(t, int64(1781000001000), obj.ModificationTime)
+		assert.Equal(t, "Public API user (key #30)", obj.Source)
+		assert.Equal(t, 7, obj.NumberOfIssues)
+	})
+
+	t.Run("empty result decodes cleanly", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": [], "objects_type": "bioc"}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		resp, err := client.ListBIOCs(context.Background(), platformTypes.ListBIOCsRequest{})
+		require.NoError(t, err)
+		assert.Zero(t, resp.ObjectsCount)
+		assert.Empty(t, resp.Objects)
+	})
+}
+
+// --- DeleteBIOCs -----------------------------------------------------------
+
+func TestClient_DeleteBIOCs(t *testing.T) {
+	t.Run("returns deleted rule_ids", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/"+DeleteBIOCsEndpoint, r.URL.Path)
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req biocDeleteRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData.Filters, 1)
+			assert.Equal(t, "rule_id", req.RequestData.Filters[0].Field)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 1, "objects": [496]}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		ids, err := client.DeleteBIOCs(context.Background(), platformTypes.DeleteBIOCsRequest{
+			Filters: []platformTypes.BIOCFilter{
+				{Field: "rule_id", Operator: "EQ", Value: 496},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []int{496}, ids)
+	})
+
+	t.Run("idempotent: empty filter result is not an error", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": []}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		ids, err := client.DeleteBIOCs(context.Background(), platformTypes.DeleteBIOCsRequest{
+			Filters: []platformTypes.BIOCFilter{
+				{Field: "rule_id", Operator: "EQ", Value: 999999},
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, ids)
+	})
+}
+
+// --- FindBIOCByID ----------------------------------------------------------
+
+func TestClient_FindBIOCByID(t *testing.T) {
+	t.Run("queries by rule_id and returns match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+
+			var raw struct {
+				RequestData struct {
+					Filters []struct {
+						Field    string `json:"field"`
+						Operator string `json:"operator"`
+						Value    any    `json:"value"`
+					} `json:"filters"`
+					ExtendedView bool `json:"extended_view"`
+				} `json:"request_data"`
+			}
+			require.NoError(t, json.Unmarshal(body, &raw))
+			require.Len(t, raw.RequestData.Filters, 1)
+			assert.Equal(t, "rule_id", raw.RequestData.Filters[0].Field)
+			assert.Equal(t, "EQ", raw.RequestData.Filters[0].Operator)
+			// JSON numbers decode to float64 in an `any` field.
+			assert.Equal(t, float64(192), raw.RequestData.Filters[0].Value)
+			assert.True(t, raw.RequestData.ExtendedView)
+
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{
+				"objects_count": 1,
+				"objects": [{"rule_id": 192, "name": "x", "type": "EXECUTION", "severity": "SEV_040_HIGH", "status": "enabled", "is_xql": true, "indicator": "dataset = xdr_data"}]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindBIOCByID(context.Background(), 192)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 192, got.RuleID)
+		assert.Equal(t, enums.BIOCTypeExecution, got.Type)
+		assert.Equal(t, enums.BIOCSeverityHigh, got.Severity)
+	})
+
+	t.Run("returns nil when no match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": []}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindBIOCByID(context.Background(), 999)
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}
+
+// --- FindBIOCByName --------------------------------------------------------
+
+func TestClient_FindBIOCByName(t *testing.T) {
+	t.Run("returns first matching record (names not unique)", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var req biocFilterRequest
+			require.NoError(t, json.Unmarshal(body, &req))
+			require.Len(t, req.RequestData.Filters, 1)
+			assert.Equal(t, "name", req.RequestData.Filters[0].Field)
+			assert.Equal(t, "EQ", req.RequestData.Filters[0].Operator)
+			assert.Equal(t, "shared-name", req.RequestData.Filters[0].Value)
+			assert.True(t, req.RequestData.ExtendedView)
+
+			w.WriteHeader(http.StatusOK)
+			// Two BIOCs share the name on this tenant; the helper
+			// returns the first match.
+			fmt.Fprint(w, `{
+				"objects_count": 2,
+				"objects": [
+					{"rule_id": 9, "name": "shared-name", "type": "EXECUTION", "severity": "SEV_020_LOW"},
+					{"rule_id": 11, "name": "shared-name", "type": "EXECUTION", "severity": "SEV_020_LOW"}
+				]
+			}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindBIOCByName(context.Background(), "shared-name")
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		assert.Equal(t, 9, got.RuleID)
+	})
+
+	t.Run("returns nil when no match", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprint(w, `{"objects_count": 0, "objects": [], "objects_type": "bioc"}`)
+		})
+		client, server := setupTest(t, handler)
+		defer server.Close()
+
+		got, err := client.FindBIOCByName(context.Background(), "missing")
+		require.NoError(t, err)
+		assert.Nil(t, got)
+	})
+}

--- a/platform/client.go
+++ b/platform/client.go
@@ -58,6 +58,11 @@ const (
 	// Syslog Integration Endpoints
 	CreateSyslogIntegrationEndpoint = "public_api/v1/integrations/syslog/create"
 	ListSyslogIntegrationsEndpoint  = "public_api/v1/integrations/syslog/get"
+
+	// BIOC (Behavioral Indicator of Compromise) Endpoints
+	InsertBIOCsEndpoint = "public_api/v1/bioc/insert"
+	ListBIOCsEndpoint   = "public_api/v1/bioc/get"
+	DeleteBIOCsEndpoint = "public_api/v1/bioc/delete"
 )
 
 // Option is a functional option for configuring the client.

--- a/types/platform/bioc.go
+++ b/types/platform/bioc.go
@@ -1,0 +1,128 @@
+// Copyright (c) Palo Alto Networks, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package types
+
+import (
+	"encoding/json"
+
+	"github.com/PaloAltoNetworks/cortex-cloud-go/enums"
+)
+
+// ----------------------------------------------------------------------------
+// BIOC
+// ----------------------------------------------------------------------------
+
+// BIOC describes a single Behavioral Indicator of Compromise as accepted by
+// /bioc/insert and returned by /bioc/get.
+//
+// The first ten fields are read+write. The remaining four are read-only:
+// they appear in GET responses but are server-assigned and not part of the
+// insert schema. CreationTime/ModificationTime/Source/NumberOfIssues are
+// undocumented in the OpenAPI spec for /bioc/get but populated by the live
+// API — observed against a live tenant.
+//
+// The Indicator field is polymorphic: when IsXQL is true it carries a raw
+// XQL query string; otherwise it carries a structured filter-AST object
+// (runOnCGO / investigationType / investigation.{TYPE}.filter.{AND|OR}[]).
+// json.RawMessage lets the SDK pass both shapes through without imposing a
+// (necessarily incomplete) Go struct for the AST.
+type BIOC struct {
+	// --- Read + Write fields ---
+	RuleID                  int                `json:"rule_id,omitempty"`
+	Name                    string             `json:"name"`
+	Type                    enums.BIOCType     `json:"type"`
+	Severity                enums.BIOCSeverity `json:"severity"`
+	Status                  enums.BIOCStatus   `json:"status"`
+	Comment                 string             `json:"comment"`
+	IsXQL                   bool               `json:"is_xql"`
+	Indicator               json.RawMessage    `json:"indicator"`
+	MitreTacticIDAndName    []string           `json:"mitre_tactic_id_and_name"`
+	MitreTechniqueIDAndName []string           `json:"mitre_technique_id_and_name"`
+
+	// --- Read-only fields (server-assigned, returned by /bioc/get) ---
+	CreationTime     int64  `json:"creation_time,omitempty"`
+	ModificationTime int64  `json:"modification_time,omitempty"`
+	Source           string `json:"source,omitempty"`
+	NumberOfIssues   int    `json:"number_of_issues,omitempty"`
+}
+
+// BIOCFilter is a single filter expression used by bioc/get and bioc/delete.
+// Filter `value` is polymorphic — booleans (`is_xql`) must be JSON booleans,
+// integers (`rule_id`) must be JSON numbers, everything else passes through
+// as a string.
+//
+// Note: the OpenAPI filter `field` enum lists name/severity/type/is_xql/
+// comment/status/indicator/mitre_*; rule_id is undocumented but accepted on
+// EQ by both bioc/get and bioc/delete (verified against a live tenant).
+// FindBIOCByID and DeleteBIOCsByRuleID rely on this behavior.
+type BIOCFilter struct {
+	Field    string `json:"field"`
+	Operator string `json:"operator"`
+	Value    any    `json:"value"`
+}
+
+// ListBIOCsRequest is the request body for bioc/get. ExtendedView toggles
+// inclusion of additional fields in the response (in practice the live API
+// returns the same field set either way for BIOCs created via /insert).
+type ListBIOCsRequest struct {
+	Filters      []BIOCFilter `json:"filters,omitempty"`
+	ExtendedView bool         `json:"extended_view,omitempty"`
+	SearchFrom   int          `json:"search_from,omitempty"`
+	SearchTo     int          `json:"search_to,omitempty"`
+}
+
+// DeleteBIOCsRequest is the request body for bioc/delete. The API has no
+// by-ID delete: callers must construct a filter that matches the BIOC(s) to
+// remove. The undocumented `rule_id` filter field is the only safe identity
+// key — BIOC names are not unique on a tenant.
+type DeleteBIOCsRequest struct {
+	Filters []BIOCFilter `json:"filters"`
+}
+
+// InsertBIOCsResponse is returned by /bioc/insert. Created records appear in
+// AddedObjects; overwritten records appear in UpdatedObjects. Per-record
+// failures appear in Errors keyed by the original index inside the batch.
+//
+// Unlike /indicators/insert, the BIOC endpoint returns HTTP 400 (not 200)
+// when any record fails validation, but the body still uses the success
+// shape. The SDK insert helper handles this and returns the typed response
+// rather than the raw HTTP error.
+type InsertBIOCsResponse struct {
+	AddedObjects   []BIOCInsertResult `json:"added_objects,omitempty"`
+	UpdatedObjects []BIOCInsertResult `json:"updated_objects,omitempty"`
+	Errors         []BIOCInsertError  `json:"errors,omitempty"`
+}
+
+// BIOCInsertResult is one entry inside AddedObjects/UpdatedObjects from
+// /bioc/insert.
+type BIOCInsertResult struct {
+	ID     int    `json:"id"`
+	Status string `json:"status"`
+}
+
+// BIOCInsertError is one entry inside Errors from /bioc/insert. Index is the
+// zero-based position of the failing record inside the original request
+// batch; Status is the server-supplied failure reason. The OpenAPI spec
+// declares Errors items as strings, but the live API returns objects with
+// {index, status} (verified against a live tenant).
+type BIOCInsertError struct {
+	Index  int    `json:"index"`
+	Status string `json:"status"`
+}
+
+// ListBIOCsResponse is returned by /bioc/get.
+type ListBIOCsResponse struct {
+	ObjectsCount int    `json:"objects_count"`
+	ObjectsType  string `json:"objects_type"`
+	Objects      []BIOC `json:"objects"`
+}
+
+// DeleteBIOCsResponse is returned by /bioc/delete. Objects carries the
+// server-assigned rule_ids that were removed; ObjectsCount is the length of
+// that slice. Delete is idempotent — deleting a non-existent BIOC returns
+// `{objects_count: 0, objects: []}` with no error.
+type DeleteBIOCsResponse struct {
+	ObjectsCount int   `json:"objects_count"`
+	Objects      []int `json:"objects"`
+}


### PR DESCRIPTION
## Summary

Adds first-class support for `/public_api/v1/bioc/{insert,get,delete}` to the platform module:

- New `BIOC` and `BIOCFilter` types with the ten write-allowed fields plus four read-only fields the live API returns (`creation_time`, `modification_time`, `source`, `number_of_issues`). `BIOC.Indicator` is `json.RawMessage` to keep the SDK schema-agnostic over the polymorphic payload (JSON string when `is_xql=true`, structured filter AST otherwise).
- New `Client.InsertBIOCs` (upsert via `rule_id`), `Client.ListBIOCs`, `Client.DeleteBIOCs`, and convenience helpers `Client.FindBIOCByName` / `Client.FindBIOCByID`. Unlike `/indicators/insert`, `/bioc/insert` returns HTTP 400 with the success-shape body on per-record validation failure — `InsertBIOCs` recovers the typed response so callers don't need to special-case that path.
- New `enums` package additions: `BIOCType` (16 values), `BIOCSeverity`, and `BIOCStatus` (string-aliased) with canonical-set helpers. Includes `SEV_050_CRITICAL`, which the live API accepts even though the OpenAPI insert enum omits it.

BIOC names are not unique per tenant — `FindBIOCByID` is the only safe identity-based lookup; `FindBIOCByName` returns the first match and is reserved for ad-hoc CLI work.

## Test plan

- [x] `go test ./platform/...` — 16 unit sub-tests covering the three endpoints, the structured `errors[{index,status}]` shape on both HTTP 200 and HTTP 400, the no-`reply` wrapper on success, the polymorphic indicator round-trip, and both `FindBIOCBy*` helpers.
- [x] `go test -tags=acceptance -run TestAccBIOC ./platform/...` — five lifecycle / structured-indicator / `SEV_050_CRITICAL` / idempotent-delete / non-unique-name tests against a live tenant; all green, tenant left clean.
- [x] `go vet ./platform/... ./types/... ./enums/...` clean.